### PR TITLE
Simplify test runner script

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,1 @@
-{ }
+{ "video": false }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,16 +3,12 @@
 set -o pipefail
 set -e
 
-# Catch a SIGINT or SIGTERM and trigger a script EXIT (e.g. to catch ctrl+c)
-trap "exit" SIGINT SIGTERM
-# Kill this process and all of its childen when this script exits.
-trap "kill 0" EXIT
-
 # Run a background HTTP server to serve our JavaScript and test against.
 ./node_modules/.bin/simplehttpserver . &
+TEST_SERVER_PID=$!
 
 # Run our tests.
 ./node_modules/.bin/cypress run
-TESTS_EXIT_CODE=$?
 
-exit $TESTS_EXIT_CODE
+# Kill our backgrounded server.
+kill $TEST_SERVER_PID


### PR DESCRIPTION
Also turns off Cypress' option to take video snapshots, which we don't need.