### PR TITLE
CI refinements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,7 @@ version: 2.1
 default_steps: &default_steps
   steps:
     - checkout
-    - restore_cache:
-        keys:
-        - v1-dependencies-{{ checksum "package.json" }}
-        # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
-    - run: npm install
-    - save_cache:
-        paths:
-          - node_modules
-        key: v1-dependencies-{{ checksum "package.json" }}
+    - run: npm ci
     - run: npm test
 
 jobs:


### PR DESCRIPTION
Use `npm ci` and don't use CircleCI cache.