### PR TITLE
Add supply-chain hardened .npmrc (PER-8339)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Supply-chain hardening — required by the weekly .npmrc audit (PER / SC-12282)
+# https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+audit-level=high
+engine-strict=true
+legacy-peer-deps=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
-# Supply-chain hardening — required by the weekly .npmrc audit (PER / SC-12282)
-# https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec
 ignore-scripts=true
 strict-ssl=true
 save-exact=true


### PR DESCRIPTION
## Supply-chain hardening: add `.npmrc`

This repo was flagged by the weekly supply-chain `.npmrc` audit ([PER-8339](https://browserstack.atlassian.net/browse/PER-8339), parent [SC-12282](https://browserstack.atlassian.net/browse/SC-12282)) with status `missing_file`.

Adds an `.npmrc` with the required hardening directives:

| Directive | Purpose |
|-----------|---------|
| `ignore-scripts=true` | blocks malicious lifecycle scripts |
| `strict-ssl=true` | enforces TLS |
| `save-exact=true` | pins exact versions |
| `audit-level=high` | fail on high+ advisories |
| `engine-strict=true` | refuse incompatible Node engines |
| `legacy-peer-deps=false` | preserves npm 7+ peer-dep resolution |

Public repo, so `access=restricted` is intentionally omitted (private-repo only).

> ⚠️ Reviewers: please confirm CI `npm install` still passes — `ignore-scripts`, `engine-strict`, and `legacy-peer-deps` can change install behavior.

Ref: [Supply Chain Security Enhancements Tech Spec](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec)

[PER-8339]: https://browserstack.atlassian.net/browse/PER-8339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-12282]: https://browserstack.atlassian.net/browse/SC-12282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ